### PR TITLE
Add basic React TS skeleton for Tak game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Tak
+
+This repository contains a small TypeScript + React implementation of the board game **Tak**.
+
+## Development
+
+Install dependencies and build the project:
+
+```bash
+npm install
+npm run build
+```
+
+Open `public/index.html` in a browser to run the app.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tak",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tak</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../dist/index.js"></script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Game, Player, PieceType } from './game/Game';
+import BoardView from './components/BoardView';
+
+const DEFAULT_SIZE = 5;
+
+export default function App() {
+  const [game, setGame] = useState(() => new Game(DEFAULT_SIZE));
+  const [selectedPiece, setSelectedPiece] = useState<PieceType>(PieceType.Flat);
+
+  const handlePlace = (x: number, y: number) => {
+    if (game.place(x, y, selectedPiece)) {
+      setGame(game.clone());
+    }
+  };
+
+  return (
+    <div>
+      <h1>Tak</h1>
+      <BoardView board={game.board} onPlace={handlePlace} />
+    </div>
+  );
+}

--- a/src/components/BoardView.tsx
+++ b/src/components/BoardView.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Board, Stack } from '../game/Board';
+import SquareView from './SquareView';
+
+interface BoardViewProps {
+  board: Board;
+  onPlace: (x: number, y: number) => void;
+}
+
+export default function BoardView({ board, onPlace }: BoardViewProps) {
+  return (
+    <div style={{ display: 'inline-block' }}>
+      {board.grid.map((row, y) => (
+        <div key={y} style={{ display: 'flex' }}>
+          {row.map((stack, x) => (
+            <SquareView key={x} stack={stack} onClick={() => onPlace(x, y)} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/SquareView.tsx
+++ b/src/components/SquareView.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Stack } from '../game/Board';
+import { PieceType, Player } from '../game/types';
+
+interface SquareProps {
+  stack: Stack;
+  onClick?: () => void;
+}
+
+function pieceColor(player: Player): string {
+  return player === Player.White ? '#eee' : '#333';
+}
+
+export default function SquareView({ stack, onClick }: SquareProps) {
+  const top = stack[stack.length - 1];
+  const style: React.CSSProperties = {
+    width: 50,
+    height: 50,
+    border: '1px solid #555',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: top ? pieceColor(top.player) : '#fafafa',
+  };
+  let content: React.ReactNode = null;
+  if (top) {
+    if (top.type === PieceType.Flat) {
+      content = null;
+    } else if (top.type === PieceType.Wall) {
+      content = <div style={{ transform: 'rotate(45deg)', width: 20, height: 20, background: '#888' }} />;
+    } else if (top.type === PieceType.Capstone) {
+      content = <div style={{ width: 30, height: 30, borderRadius: '50%', background: '#444' }} />;
+    }
+  }
+
+  return (
+    <div style={style} onClick={onClick}>
+      {content}
+      {stack.length > 1 && (
+        <span style={{ position: 'absolute', fontSize: 12 }}>{stack.length}</span>
+      )}
+    </div>
+  );
+}

--- a/src/game/Board.ts
+++ b/src/game/Board.ts
@@ -1,0 +1,30 @@
+import { Piece } from './types';
+
+export type Stack = Piece[];
+
+export class Board {
+  size: number;
+  grid: Stack[][];
+
+  constructor(size: number) {
+    this.size = size;
+    this.grid = [];
+    for (let y = 0; y < size; y++) {
+      const row: Stack[] = [];
+      for (let x = 0; x < size; x++) {
+        row.push([]);
+      }
+      this.grid.push(row);
+    }
+  }
+
+  clone(): Board {
+    const b = new Board(this.size);
+    b.grid = this.grid.map(row => row.map(stack => [...stack]));
+    return b;
+  }
+
+  getStack(x: number, y: number): Stack {
+    return this.grid[y][x];
+  }
+}

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -1,0 +1,53 @@
+import { Board } from './Board';
+import { Player, PieceType, Piece } from './types';
+
+export class Game {
+  board: Board;
+  current: Player = Player.White;
+  flats: Record<Player, number>;
+  capstones: Record<Player, number>;
+
+  constructor(size: number) {
+    this.board = new Board(size);
+    this.flats = {
+      [Player.White]: size * size,
+      [Player.Black]: size * size,
+    };
+    this.capstones = {
+      [Player.White]: 1,
+      [Player.Black]: 1,
+    };
+  }
+
+  clone(): Game {
+    const g = new Game(this.board.size);
+    g.board = this.board.clone();
+    g.current = this.current;
+    g.flats = { ...this.flats };
+    g.capstones = { ...this.capstones };
+    return g;
+  }
+
+  place(x: number, y: number, type: PieceType): boolean {
+    const stack = this.board.getStack(x, y);
+    if (stack.length > 0) return false;
+    if (type === PieceType.Capstone && this.capstones[this.current] === 0) return false;
+    if (type !== PieceType.Capstone && this.flats[this.current] === 0) return false;
+
+    const piece: Piece = { player: this.current, type };
+    stack.push(piece);
+    if (type === PieceType.Capstone) {
+      this.capstones[this.current]--;
+    } else {
+      this.flats[this.current]--;
+    }
+    this.toggle();
+    return true;
+  }
+
+  toggle() {
+    this.current = this.current === Player.White ? Player.Black : Player.White;
+  }
+}
+
+export { Player, PieceType } from './types';

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,15 @@
+export enum Player {
+  White = 'W',
+  Black = 'B',
+}
+
+export enum PieceType {
+  Flat = 'flat',
+  Wall = 'wall',
+  Capstone = 'capstone',
+}
+
+export interface Piece {
+  player: Player;
+  type: PieceType;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "lib": ["dom", "es2015"],
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add an initial React+TypeScript project skeleton
- implement basic game data structures for board and pieces
- simple React components to render the board and allow piece placement
- document build steps

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*